### PR TITLE
Displaying tooltips only when needed

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -10,11 +10,13 @@ export default function (Alpine) {
 
         effect(() => {
             getContent(content => {
-                if (!el.__x_tippy) {
-                    el.__x_tippy = tippy(el, config)
-                }
+                if(content) {
+                    if (!el.__x_tippy) {
+                        el.__x_tippy = tippy(el, config)
+                    }
 
-                el.__x_tippy.setContent(content)
+                    el.__x_tippy.setContent(content)
+                }
             })
         })
     })


### PR DESCRIPTION
I imagine this small change would allow users to display tooltip only when tooltip content is passed. 
That would make possible of showing (or not showing) tooltips depending on some parent Alpine state (for example turn off when regular labels are visible and turn on when Alpine hides labels and displays only icons). 
Example: <span x-data="{tooltip: (onlyIcons ? '{{$title}}' : false)}" x-tooltip.arrowless.theme.light.placement.right="tooltip">