### PR TITLE
fix/webpack build

### DIFF
--- a/src/buildConfigFromModifiers.js
+++ b/src/buildConfigFromModifiers.js
@@ -20,7 +20,7 @@ export const buildConfigFromModifiers = modifiers => {
     if (modifiers.includes('cursor')) {
         config.plugins.push(followCursor)
 
-        const next = modifiers[modifiers.indexOf('cursor') + 1] ? modifiers[modifiers.indexOf('cursor') + 1] : null
+        const next = modifiers[modifiers.indexOf('cursor') + 1];
 
         if (['x', 'initial'].includes(next)) {
             config.followCursor = next === 'x' ? 'horizontal' : 'initial'


### PR DESCRIPTION
Hi man,

first, let me say thank you, for your alpine-Plugins and all your work in OSS!

You rock. 🙌🏼

What this PR does:
- fixes the builder with (older) webpack (3) / babel (7)


Why?

When i wanted to build my asset bundle I got the following error:
![Bildschirmfoto 2021-10-28 um 12 55 19](https://user-images.githubusercontent.com/10073766/139249191-2a1feeed-343d-4e88-a69e-1d520f3e2296.jpg)


So the Nullish coalescing operator is creating the problem. With the changed line from this PR it works.

I think it may occur because I'm on an old Babel (7) or webpack (3). Currently other dependencies are holding me back from upgrade.

I tried this babel plugin https://babeljs.io/docs/en/babel-plugin-proposal-nullish-coalescing-operator, but it does not seem to work.


Cheers!